### PR TITLE
一个UI的bug, 两优化,侧边栏的数据和UI分离,gitignore 增加package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .idea
+package-lock.json

--- a/src/components/SiderCustom.jsx
+++ b/src/components/SiderCustom.jsx
@@ -2,10 +2,12 @@
  * Created by hao.cheng on 2017/4/13.
  */
 import React, { Component } from 'react';
-import { Layout, Menu, Icon } from 'antd';
-import { Link, withRouter } from 'react-router-dom';
+import { Layout } from 'antd';
+import { withRouter } from 'react-router-dom';
+import { menus } from '../constants/menus';
+import SiderMenu from './SiderMenu';
+
 const { Sider } = Layout;
-const SubMenu = Menu.SubMenu;
 
 class SiderCustom extends Component {
     state = {
@@ -24,7 +26,7 @@ class SiderCustom extends Component {
         this.setMenuOpen(nextProps)
     }
     setMenuOpen = props => {
-        const {pathname} = props.location;
+        const { pathname } = props.location;
         this.setState({
             openKey: pathname.substr(0, pathname.lastIndexOf('/')),
             selectedKey: pathname
@@ -59,82 +61,18 @@ class SiderCustom extends Component {
                 trigger={null}
                 breakpoint="lg"
                 collapsed={this.props.collapsed}
-                style={{overflowY: 'auto'}}
+                style={{ overflowY: 'auto' }}
             >
                 <div className="logo" />
-                <Menu
+                <SiderMenu
+                    menus={menus}
                     onClick={this.menuClick}
                     theme="dark"
                     mode="inline"
                     selectedKeys={[this.state.selectedKey]}
                     openKeys={this.state.firstHide ? null : [this.state.openKey]}
                     onOpenChange={this.openMenu}
-                >
-                    <Menu.Item key="/app/dashboard/index">
-                        <Link to={'/app/dashboard/index'}><Icon type="mobile" /><span className="nav-text">首页</span></Link>
-                    </Menu.Item>
-                    <SubMenu
-                        key="/app/ui"
-                        title={<span><Icon type="scan" /><span className="nav-text">UI</span></span>}
-                    >
-
-                        <Menu.Item key="/app/ui/buttons"><Link to={'/app/ui/buttons'}>按钮</Link></Menu.Item>
-                        <Menu.Item key="/app/ui/icons"><Link to={'/app/ui/icons'}>图标</Link></Menu.Item>
-                        <Menu.Item key="/app/ui/spins"><Link to={'/app/ui/spins'}>加载中</Link></Menu.Item>
-                        <Menu.Item key="/app/ui/modals"><Link to={'/app/ui/modals'}>对话框</Link></Menu.Item>
-                        <Menu.Item key="/app/ui/notifications"><Link to={'/app/ui/notifications'}>通知提醒框</Link></Menu.Item>
-                        <Menu.Item key="/app/ui/tabs"><Link to={'/app/ui/tabs'}>标签页</Link></Menu.Item>
-                        <Menu.Item key="/app/ui/banners"><Link to={'/app/ui/banners'}>轮播图</Link></Menu.Item>
-                        <Menu.Item key="/app/ui/wysiwyg"><Link to={'/app/ui/wysiwyg'}>富文本</Link></Menu.Item>
-                        <Menu.Item key="/app/ui/drags"><Link to={'/app/ui/drags'}>拖拽</Link></Menu.Item>
-                        <Menu.Item key="/app/ui/gallery"><Link to={'/app/ui/gallery'}>画廊</Link></Menu.Item>
-                    </SubMenu>
-                    <SubMenu
-                        key="/app/animation"
-                        title={<span><Icon type="rocket" /><span className="nav-text">动画</span></span>}
-                    >
-
-                        <Menu.Item key="/app/animation/basicAnimations"><Link to={'/app/animation/basicAnimations'}>基础动画</Link></Menu.Item>
-                        <Menu.Item key="/app/animation/exampleAnimations"><Link to={'/app/animation/exampleAnimations'}>动画案例</Link></Menu.Item>
-                    </SubMenu>
-                    <SubMenu
-                        key="/app/table"
-                        title={<span><Icon type="copy" /><span className="nav-text">表格</span></span>}
-                    >
-
-                        <Menu.Item key="/app/table/basicTable"><Link to={'/app/table/basicTable'}>基础表格</Link></Menu.Item>
-                        <Menu.Item key="/app/table/advancedTable"><Link to={'/app/table/advancedTable'}>高级表格</Link></Menu.Item>
-                        <Menu.Item key="/app/table/asynchronousTable"><Link to={'/app/table/asynchronousTable'}>异步表格</Link></Menu.Item>
-                    </SubMenu>
-                    <SubMenu
-                        key="/app/form"
-                        title={<span><Icon type="edit" /><span className="nav-text">表单</span></span>}
-                    >
-
-                        <Menu.Item key="/app/basicForm"><Link to={'/app/form/basicForm'}>基础表单</Link></Menu.Item>
-                    </SubMenu>
-                    <SubMenu
-                        key="/app/chart"
-                        title={<span><Icon type="area-chart" /><span className="nav-text">图表</span></span>}
-                    >
-                        <Menu.Item key="/app/chart/echarts"><Link to={'/app/chart/echarts'}>echarts</Link></Menu.Item>
-                        <Menu.Item key="/app/chart/recharts"><Link to={'/app/chart/recharts'}>recharts</Link></Menu.Item>
-                    </SubMenu>
-                    <SubMenu
-                        key="sub4"
-                        title={<span><Icon type="switcher" /><span className="nav-text">页面</span></span>}
-                    >
-                        <Menu.Item key="/login"><Link to={'/login'}>登录</Link></Menu.Item>
-                        <Menu.Item key="/404"><Link to={'/404'}>404</Link></Menu.Item>
-                    </SubMenu>
-                    <SubMenu
-                        key="/app/auth"
-                        title={<span><Icon type="safety" /><span className="nav-text">权限管理</span></span>}
-                    >
-                        <Menu.Item key="/app/auth/basic"><Link to={'/app/auth/basic'}>基础演示</Link></Menu.Item>
-                        <Menu.Item key="/app/auth/routerEnter"><Link to={'/app/auth/routerEnter'}>路由拦截</Link></Menu.Item>
-                    </SubMenu>
-                </Menu>
+                />
                 <style>
                     {`
                     #nprogress .spinner{

--- a/src/components/SiderMenu.js
+++ b/src/components/SiderMenu.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Menu, Icon } from 'antd';
+import { Link } from 'react-router-dom';
+
+const renderMenuItem =
+    ({ key, title, icon, link, ...props }) =>
+        <Menu.Item
+            key={key || link}
+            {...props}
+        >
+            <Link to={link || key}>
+                {icon && <Icon type={icon} />}
+                <span className="nav-text">{title}</span>
+            </Link>
+        </Menu.Item>;
+
+const renderSubMenu =
+    ({ key, title, icon, link, sub, ...props }) =>
+        <Menu.SubMenu
+            key={key || link}
+            title={
+                <span>
+                    {icon && <Icon type={icon} />}
+                    <span className="nav-text">{title}</span>
+                </span>
+            }
+            {...props}
+        >
+            {sub && sub.map(item => renderMenuItem(item))}
+        </Menu.SubMenu>;
+
+export default ({ menus, ...props }) => <Menu {...props}>
+    {menus && menus.map(
+        item => item.sub && item.sub.length ?
+            renderSubMenu(item) : renderMenuItem(item)
+    )}
+</Menu>;

--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -1,0 +1,60 @@
+export const menus = [
+    { key: '/app/dashboard/index', title: '首页', icon: 'mobile', },
+    {
+        key: '/app/ui', title: 'UI', icon: 'scan',
+        sub: [
+            { key: '/app/ui/buttons', title: '按钮', icon: '', },
+            { key: '/app/ui/icons', title: '图标', icon: '', },
+            { key: '/app/ui/spins', title: '加载中', icon: '', },
+            { key: '/app/ui/modals', title: '对话框', icon: '', },
+            { key: '/app/ui/notifications', title: '通知提醒框', icon: '', },
+            { key: '/app/ui/tabs', title: '标签页', icon: '', },
+            { key: '/app/ui/banners', title: '轮播图', icon: '', },
+            { key: '/app/ui/wysiwyg', title: '富文本', icon: '', },
+            { key: '/app/ui/drags', title: '拖拽', icon: '', },
+            { key: '/app/ui/gallery', title: '画廊', icon: '', },
+        ],
+    },
+    {
+        key: '/app/animation', title: '动画', icon: 'rocket',
+        sub: [
+            { key: '/app/animation/basicAnimations', title: '基础动画', icon: '', },
+            { key: '/app/animation/exampleAnimations', title: '动画案例', icon: '', },
+        ],
+    },
+    {
+        key: '/app/table', title: '表格', icon: 'copy',
+        sub: [
+            { key: '/app/table/basicTable', title: '基础表格', icon: '', },
+            { key: '/app/table/advancedTable', title: '高级表格', icon: '', },
+            { key: '/app/table/asynchronousTable', title: '异步表格', icon: '', },
+        ],
+    },
+    {
+        key: '/app/form', title: '表单', icon: 'edit',
+        sub: [
+            { key: '/app/form/basicForm', title: '基础表单', icon: '', },
+        ],
+    },
+    {
+        key: '/app/chart', title: '图表', icon: 'area-chart',
+        sub: [
+            { key: '/app/chart/echarts', title: 'echarts', icon: '', },
+            { key: '/app/chart/recharts', title: 'recharts', icon: '', },
+        ],
+    },
+    {
+        key: '/sub4', title: '页面', icon: 'switcher',
+        sub: [
+            { key: '/login', title: '登录', icon: '', },
+            { key: '/404', title: '404', icon: '', },
+        ],
+    },
+    {
+        key: '/app/auth', title: '权限管理', icon: 'safety',
+        sub: [
+            { key: '/app/auth/basic', title: '基础演示', icon: '', },
+            { key: '/app/auth/routerEnter', title: '路由拦截', icon: '', },
+        ],
+    },
+];

--- a/src/style/index.less
+++ b/src/style/index.less
@@ -37,6 +37,9 @@
     .ant-menu-submenu-vertical > .ant-menu-submenu-title:after{
       display: none;
     }
+    .ant-menu-dark:not(.ant-menu-inline) .ant-menu-submenu-open {
+      color: inherit;
+    }
   }
   p {
     margin: 10px 0 10px 0;


### PR DESCRIPTION
第一回用pull request，有种code review的既视感，感觉有点意思
三个commit除了分离侧边栏的那个提交，其他两个改动比较简单，
下面我详细说说分离侧边栏代码改动：
* 将原来的`<Menu>...</Menu>`部分提取出来做无状态组件`SiderMenu`
	* `SiderMenu` 的`props`中menus用来传递菜单数据,其余`props`全部继承传给`Menu`
* 菜单数据`menus`是一个数组,每个数组元素为
```js
// 无二级菜单 key:路由信息 title:中文label icon:图标Icon组件的type属性
{ key: '/app/dashboard/index', title: '首页', icon: 'mobile', },

// 有二级菜单 基本和一级菜单一致, 多了个sub属性,sub是个数组,数组元素和前面介绍的格式一致
{
	key: '/app/ui', title: 'UI', icon: 'scan',
	sub: [
		{ key: '/app/ui/buttons', title: '按钮', icon: '', },
		{ key: '/app/ui/icons', title: '图标', icon: '', },
		{ key: '/app/ui/spins', title: '加载中', icon: '', },
		{ key: '/app/ui/modals', title: '对话框', icon: '', },
		{ key: '/app/ui/notifications', title: '通知提醒框', icon: '', },
		{ key: '/app/ui/tabs', title: '标签页', icon: '', },
		{ key: '/app/ui/banners', title: '轮播图', icon: '', },
		{ key: '/app/ui/wysiwyg', title: '富文本', icon: '', },
		{ key: '/app/ui/drags', title: '拖拽', icon: '', },
		{ key: '/app/ui/gallery', title: '画廊', icon: '', },
	],
},
```