### PR TITLE
refactor: enable axios get and post method pass customized callback

### DIFF
--- a/src/axios/tools.js
+++ b/src/axios/tools.js
@@ -11,10 +11,10 @@ import { message } from 'antd';
  * @param msg       接口异常提示
  * @param headers   接口所需header配置
  */
-export const get = ({ url, msg = '接口异常', config }) =>
+export const get = ({ url, msg = '接口异常', config, callback = res => res.data }) =>
     axios
         .get(url, config)
-        .then(res => res.data)
+        .then(callback)
         .catch(err => {
             console.log(err);
             message.warn(msg);
@@ -27,10 +27,10 @@ export const get = ({ url, msg = '接口异常', config }) =>
  * @param msg       接口异常提示
  * @param headers   接口所需header配置
  */
-export const post = ({ url, data, msg = '接口异常', config }) =>
+export const post = ({ url, data, msg = '接口异常', config, callback = res => res.data }) =>
     axios
         .post(url, data, config)
-        .then(res => res.data)
+        .then(callback)
         .catch(err => {
             console.log(err);
             message.warn(msg);


### PR DESCRIPTION
axios发送get/post请求后，有时用户需要定制化的callback，而不是默认把resp=> resp.data

比如我的后台服务器Login API返回的response body的格式和react-admin默认不一样，需要如下定制的callback

```javascript
export const login = loginJson =>
    post({
        url: config.MOCK_AUTH,
        data: loginJson,
        config: {
            headers: {
                'Content-Type': 'application/json',
            },
        },
        callback: resp => {
            if (resp.status === 200 && resp.data && resp.data.token) {
                setupAxiosInterceptors(resp.data.token);
                return {
                    uid: loginJson.username,
                    permissions: resp.data.permissions,
                    token: resp.data.token,
                };
            } else {
                return resp.data;
            }
        },
    });
```
